### PR TITLE
sets tab title in previewer only

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -371,7 +371,6 @@ define(function(require, exports, module) {
                 pane: pane,
                 active: active !== false,
                 document: {
-                    title: "[P] " + path,
                     preview: {
                         path: path
                     }

--- a/previewers/raw.js
+++ b/previewers/raw.js
@@ -80,9 +80,9 @@ define(function(require, exports, module) {
         plugin.on("navigate", function(e) {
             var tab = plugin.activeDocument.tab;
             var session = plugin.activeSession;
-            
-            tab.title = 
+
             tab.tooltip = "[R] " + e.url;
+            tab.title = session.doc.title || tab.tooltip;
             session.editor.setLocation(e.url);
             
             update();


### PR DESCRIPTION
We have some applications that leverage the browser previewer, and it would be good to have more control over the title of the preview tab. This PR leaves it for the previewer to set the title of the tab. It just respects the document's title, and uses the default title (in case document title is not set).

cc @dmalan